### PR TITLE
Update logo to include organisation name and descriptor

### DIFF
--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -32,7 +32,7 @@ const Layout = ({
       <a className="nhsuk-skip-link" href="#maincontent">
         Skip to main content
       </a>
-      <header className="nhsuk-header" role="banner">
+      <header className="nhsuk-header nhsuk-header--organisation" role="banner">
         <div className="nhsuk-width-container nhsuk-header__container">
           <div className="nhsuk-header__logo nhsuk-header__logo--only">
             <HeaderLink enabled={!!showNavigationBarForType}>

--- a/src/components/Logo/index.js
+++ b/src/components/Logo/index.js
@@ -17,6 +17,12 @@ const Logo = () => {
         ></path>
         <image src="https://assets.nhs.uk/images/nhs-logo.png"></image>
       </svg>
+      <span className="nhsuk-organisation-name">
+        Kettering General Hospital
+      </span>
+      <span className="nhsuk-organisation-descriptor">
+        NHS Foundation Trust
+      </span>
     </>
   );
 };


### PR DESCRIPTION
# What
Updated the logo to include the Trust name and descriptor (NHS Foundation Trust)

# Why
So that the app is clearly identified as being a part of the Kettering Trust

# Screenshots
### Before
![localhost_3000_wards_visits(iPad) (3)](https://user-images.githubusercontent.com/7527178/88194746-13762980-cc37-11ea-8a4c-489465f70725.png)
### After
![localhost_3000_wards_visits(iPad) (1)](https://user-images.githubusercontent.com/7527178/88194754-153fed00-cc37-11ea-8671-7af3d311d131.png)

# Notes
